### PR TITLE
v0.5.0, RpcProc params argument is now varargs[string]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ Desktop.ini
 
 nimcache
 *.exe
+*.html

--- a/README.md
+++ b/README.md
@@ -17,28 +17,28 @@ Helper library for writing [Wox](http://getwox.com/) plugins in [Nim](http://nim
 ## Usage
 
 ```Nimrod
-import browsers
+import browsers, json
 import wox
 
-proc query(query: string) =
+proc query(wp: Wox, params: varargs[string]) =
   # create a global Wox object
-  var wp = newWox()
   # add an item to Wox
   wp.add("Github", "How people build software", "Images\\gh.png",
           "openUrl", "https://github.com/", false)
   # send output to Wox
   echo wp.results()
-  
-proc openUrl(url: string) =
+
+proc openUrl(wp: Wox, params: varargs[string]) =
   # open url in default browser
-  openDefaultBrowser(url)
-  
+  openDefaultBrowser(params[0])
+
 when isMainModule:
+  var wp = newWox()
   # register `query` and `openUrl` for call from Wox
-  register("query", query)
-  register("openUrl", openUrl)
+  wp.register("query", query)
+  wp.register("openUrl", openUrl)
   # run called proc
-  run()
+  wp.run()
 ```
 
 ## Documentation

--- a/tests/woxtests.nim
+++ b/tests/woxtests.nim
@@ -21,6 +21,8 @@ suite "testing wox.nim":
     copyFile(pluginFile, pluginPath)
     var wp = newWox()
 
+    proc test(w: Wox, params: varargs[string]) = discard
+
   teardown:
     removeFile(pluginPath)
 
@@ -89,3 +91,16 @@ suite "testing wox.nim":
       wp.add(item)
     wp.sort("test", minScore = 10)
     check len(wp.data.result) == 7
+
+  test "register proc":
+    wp.register("test", test)
+
+  test "call proc":
+    wp.call("test", "single param")
+    wp.call("test", "params 1", "params 2")
+    wp.call("test", ["array param 1", "array param 2"])
+    wp.call("test", @["seq param 1", "seq param 2"])
+
+  test "run proc":
+    let rpc = """{"method": "test", "parameters": ["test param 1", "test param 2"]}"""
+    wp.run(rpc)


### PR DESCRIPTION
RpcProc params argument is now `varargs[string]`
Wox is now `ref object`
Added Wox object to all RpcProc related functions
Added new tests
